### PR TITLE
Add initial exploring map with OSM

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,1 +1,36 @@
+const map = L.map('map').setView([0, 0], 16);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '© OpenStreetMap'
+}).addTo(map);
 
+const mask = document.getElementById('mask');
+const exploreBtn = document.getElementById('explore');
+const RADIUS_METERS = 9;
+let watchId;
+
+function updateMask(latlng) {
+  map.setView(latlng);
+  const point = map.latLngToContainerPoint(latlng);
+  const latlngRight = map.containerPointToLatLng([point.x + 1, point.y]);
+  const metersPerPixel = latlng.distanceTo(latlngRight);
+  const radiusPx = RADIUS_METERS / metersPerPixel;
+  mask.style.clipPath = `circle(${radiusPx}px at ${point.x}px ${point.y}px)`;
+}
+
+function onLocation(pos) {
+  const latlng = L.latLng(pos.coords.latitude, pos.coords.longitude);
+  updateMask(latlng);
+}
+
+function startExplore() {
+  if (watchId) return;
+  mask.style.display = 'block';
+  if (!navigator.geolocation) {
+    alert('Geolocation not supported');
+    return;
+  }
+  watchId = navigator.geolocation.watchPosition(onLocation);
+}
+
+exploreBtn.addEventListener('click', startExplore);

--- a/index.html
+++ b/index.html
@@ -1,1 +1,16 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Revealing Map</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<button id="explore">Explore</button>
+<div id="map"></div>
+<div id="mask"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="code.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,1 +1,24 @@
-
+html, body, #map, #mask {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+}
+#map {
+  position: relative;
+}
+#explore {
+  position: absolute;
+  z-index: 1000;
+  top: 10px;
+  left: 10px;
+}
+#mask {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.7);
+  pointer-events: none;
+  z-index: 500;
+  display: none;
+  clip-path: circle(0 at 0 0);
+}


### PR DESCRIPTION
## Summary
- Set up HTML skeleton with Leaflet resources, explore button, map, and mask overlay
- Style map and overlay for full-screen exploration with hidden areas
- Implement geolocation tracking to reveal a circular region as the user moves

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b773072ea483208ed7382ca7a9ce47