### PR TITLE
Add initial map exploration prototype

### DIFF
--- a/code.js
+++ b/code.js
@@ -1,1 +1,50 @@
+const map = L.map('map').setView([0, 0], 16);
 
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+const exploreBtn = document.getElementById('explore');
+const fog = document.getElementById('fog');
+
+let watchId = null;
+const revealRadius = 9; // meters (~30 ft)
+
+function metersToPixels(meters, latlng) {
+  const latlngOffset = L.latLng(latlng.lat, latlng.lng + 0.0001);
+  const p1 = map.latLngToContainerPoint(latlng);
+  const p2 = map.latLngToContainerPoint(latlngOffset);
+  const metersPerPixel = latlng.distanceTo(latlngOffset) / p1.distanceTo(p2);
+  return meters / metersPerPixel;
+}
+
+function updateFog(latlng) {
+  const point = map.latLngToContainerPoint(latlng);
+  const radiusPixels = metersToPixels(revealRadius, latlng);
+  fog.style.setProperty('--x', `${point.x}px`);
+  fog.style.setProperty('--y', `${point.y}px`);
+  fog.style.setProperty('--r', `${radiusPixels}px`);
+}
+
+exploreBtn.addEventListener('click', () => {
+  if (!navigator.geolocation) {
+    alert('Geolocation is not supported by your browser');
+    return;
+  }
+  if (watchId !== null) {
+    return; // already tracking
+  }
+  watchId = navigator.geolocation.watchPosition(
+    pos => {
+      const latlng = L.latLng(pos.coords.latitude, pos.coords.longitude);
+      map.setView(latlng, 18);
+      updateFog(latlng);
+    },
+    err => {
+      console.error(err);
+      alert('Unable to retrieve your location');
+    },
+    { enableHighAccuracy: true }
+  );
+});

--- a/index.html
+++ b/index.html
@@ -1,1 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Revealing Map</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2G6m1bjaBkPCEi0aKBslZx2drTUu/730MQCXQ64=" crossorigin="" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="map"></div>
+  <button id="explore">Explore</button>
+  <div id="fog"></div>
 
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1jRV6W55JoQK6aUe+rCk7v0ZjIRe8pTH0ql8i5A8=" crossorigin=""></script>
+  <script src="code.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,1 +1,27 @@
+html, body, #map {
+  height: 100%;
+  margin: 0;
+}
 
+#explore {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
+  padding: 8px 12px;
+}
+
+#fog {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  pointer-events: none;
+  --x: 0px;
+  --y: 0px;
+  --r: 0px;
+  mask: radial-gradient(circle var(--r) at var(--x) var(--y), transparent 0, transparent calc(var(--r) + 1px), black calc(var(--r) + 1px));
+  -webkit-mask: radial-gradient(circle var(--r) at var(--x) var(--y), transparent 0, transparent calc(var(--r) + 1px), black calc(var(--r) + 1px));
+}


### PR DESCRIPTION
## Summary
- scaffold simple web page with Leaflet map and Explore button
- add fog overlay and geolocation tracking to reveal ~30 ft area around user

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b773072ea483208ed7382ca7a9ce47