### PR TITLE
Persist visited map areas and reveal using canvas

### DIFF
--- a/code.js
+++ b/code.js
@@ -4,13 +4,20 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '&copy; OpenStreetMap contributors'
 }).addTo(map);
 
-const fog = document.getElementById('fog');
+const fogCanvas = document.getElementById('fog');
+const fogCtx = fogCanvas.getContext('2d');
 const btn = document.getElementById('exploreBtn');
 let watchId;
 let userMarker;
 let userLatLng;
+let visitedAreas = JSON.parse(localStorage.getItem('visitedAreas') || '[]');
 
 map.on('move', updateFog);
+
+if (visitedAreas.length) {
+  fogCanvas.style.display = 'block';
+  updateFog();
+}
 
 btn.addEventListener('click', () => {
   if (watchId) {
@@ -29,7 +36,9 @@ function onLocation(position) {
   const lat = position.coords.latitude;
   const lng = position.coords.longitude;
   userLatLng = [lat, lng];
-  fog.style.display = 'block';
+  fogCanvas.style.display = 'block';
+
+  addVisitedArea(userLatLng);
 
   if (!userMarker) {
     userMarker = L.circleMarker(userLatLng, {
@@ -52,17 +61,37 @@ function onError(err) {
 }
 
 function updateFog() {
-  if (!userLatLng) return;
+  if (!visitedAreas.length) return;
+  const size = map.getSize();
+  if (fogCanvas.width !== size.x || fogCanvas.height !== size.y) {
+    fogCanvas.width = size.x;
+    fogCanvas.height = size.y;
+  }
 
-  const lat = userLatLng[0];
-  const lng = userLatLng[1];
+  fogCtx.clearRect(0, 0, fogCanvas.width, fogCanvas.height);
+  fogCtx.fillStyle = 'black';
+  fogCtx.fillRect(0, 0, fogCanvas.width, fogCanvas.height);
+  fogCtx.globalCompositeOperation = 'destination-out';
+
   const radiusMeters = 100; // reveal radius in meters
-  const lngOffset = radiusMeters / (111320 * Math.cos(lat * Math.PI / 180));
-  const pointCenter = map.latLngToContainerPoint(userLatLng);
-  const pointEast = map.latLngToContainerPoint([lat, lng + lngOffset]);
-  const radiusPx = pointEast.x - pointCenter.x;
 
-  const mask = `radial-gradient(circle at ${pointCenter.x}px ${pointCenter.y}px, transparent ${radiusPx}px, black ${radiusPx}px)`;
-  fog.style.mask = mask;
-  fog.style.webkitMask = mask;
+  visitedAreas.forEach(area => {
+    const lat = area[0];
+    const lng = area[1];
+    const lngOffset = radiusMeters / (111320 * Math.cos(lat * Math.PI / 180));
+    const pointCenter = map.latLngToContainerPoint([lat, lng]);
+    const pointEast = map.latLngToContainerPoint([lat, lng + lngOffset]);
+    const radiusPx = pointEast.x - pointCenter.x;
+
+    fogCtx.beginPath();
+    fogCtx.arc(pointCenter.x, pointCenter.y, radiusPx, 0, Math.PI * 2);
+    fogCtx.fill();
+  });
+
+  fogCtx.globalCompositeOperation = 'source-over';
+}
+
+function addVisitedArea(latLng) {
+  visitedAreas.push(latLng);
+  localStorage.setItem('visitedAreas', JSON.stringify(visitedAreas));
 }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <div id="map"></div>
-  <div id="fog"></div>
+  <canvas id="fog"></canvas>
   <button id="exploreBtn">Explore</button>
 
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>


### PR DESCRIPTION
## Summary
- Replace fog div with canvas overlay to support multiple revealed regions.
- Persist visited coordinates in localStorage and redraw explored areas.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b77a627524832099537faf5be89ec3