### PR TITLE
Persist visited map areas

### DIFF
--- a/code.js
+++ b/code.js
@@ -9,6 +9,13 @@ const btn = document.getElementById('exploreBtn');
 let watchId;
 let userMarker;
 let userLatLng;
+const revealRadius = 100; // radius in meters
+
+let visitedAreas = JSON.parse(localStorage.getItem('visitedAreas') || '[]');
+if (visitedAreas.length > 0) {
+  fog.style.display = 'block';
+  updateFog();
+}
 
 map.on('move', updateFog);
 
@@ -43,7 +50,7 @@ function onLocation(position) {
   }
 
   map.setView(userLatLng, 18);
-
+  addVisitedArea(userLatLng);
   updateFog();
 }
 
@@ -52,17 +59,40 @@ function onError(err) {
 }
 
 function updateFog() {
-  if (!userLatLng) return;
+  if (visitedAreas.length === 0) return;
 
-  const lat = userLatLng[0];
-  const lng = userLatLng[1];
-  const radiusMeters = 100; // reveal radius in meters
-  const lngOffset = radiusMeters / (111320 * Math.cos(lat * Math.PI / 180));
-  const pointCenter = map.latLngToContainerPoint(userLatLng);
-  const pointEast = map.latLngToContainerPoint([lat, lng + lngOffset]);
-  const radiusPx = pointEast.x - pointCenter.x;
+  const masks = visitedAreas.map(([lat, lng]) => {
+    const lngOffset = revealRadius / (111320 * Math.cos(lat * Math.PI / 180));
+    const pointCenter = map.latLngToContainerPoint([lat, lng]);
+    const pointEast = map.latLngToContainerPoint([lat, lng + lngOffset]);
+    const radiusPx = pointEast.x - pointCenter.x;
+    return `radial-gradient(circle at ${pointCenter.x}px ${pointCenter.y}px, transparent ${radiusPx}px, black ${radiusPx}px)`;
+  });
 
-  const mask = `radial-gradient(circle at ${pointCenter.x}px ${pointCenter.y}px, transparent ${radiusPx}px, black ${radiusPx}px)`;
+  const mask = masks.join(',');
   fog.style.mask = mask;
   fog.style.webkitMask = mask;
+}
+
+function addVisitedArea([lat, lng]) {
+  const alreadyVisited = visitedAreas.some(([vLat, vLng]) =>
+    distance(vLat, vLng, lat, lng) < revealRadius
+  );
+  if (!alreadyVisited) {
+    visitedAreas.push([lat, lng]);
+    localStorage.setItem('visitedAreas', JSON.stringify(visitedAreas));
+  }
+}
+
+function distance(lat1, lng1, lat2, lng2) {
+  const R = 6371000; // meters
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLng = (lng2 - lng1) * Math.PI / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1 * Math.PI / 180) *
+      Math.cos(lat2 * Math.PI / 180) *
+      Math.sin(dLng / 2) * Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
 }


### PR DESCRIPTION
## Summary
- store visited map positions in localStorage to keep previously explored areas visible
- combine multiple radial gradients to reveal all visited regions on the fog overlay

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/RevealingMap/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b77a627524832099537faf5be89ec3