### PR TITLE
Ensure fog mask stays aligned with Leaflet map

### DIFF
--- a/code.js
+++ b/code.js
@@ -22,7 +22,9 @@ map.whenReady(() => {
   drawFog();
 });
 
-map.on('moveend zoomend', drawFog);
+// Redraw the fog whenever the map is panned or zoomed so the mask
+// stays aligned with the map view.
+map.on('move zoom', drawFog);
 window.addEventListener('resize', resizeCanvas);
 
 exploreBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Redraw fog overlay continuously during map pan and zoom events to keep revealed areas aligned.
- Add explanatory comment about syncing fog with map view.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3533027ec8320b7c2343dca2d37f0