### PR TITLE
Add ARIA labelling to map container

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,12 +15,24 @@
         <span id="level-bar-text"></span>
       </div>
     </header>
-    <main id="map"></main>
-    <section id="controls">
-      <button id="explore">Explore</button>
-      <button id="simulate">Simulate Walk</button>
-      <button id="reset-xp">Reset XP</button>
-    </section>
+    <main>
+      <div
+        id="map"
+        role="application"
+        aria-labelledby="map-heading"
+        aria-describedby="map-description"
+      ></div>
+      <h2 id="map-heading" class="visually-hidden">Exploration progress map</h2>
+      <p id="map-description" class="visually-hidden">
+        Interactive map showing the areas you have uncovered and the fog that still
+        hides unexplored locations.
+      </p>
+      <section id="controls">
+        <button id="explore">Explore</button>
+        <button id="simulate">Simulate Walk</button>
+        <button id="reset-xp">Reset XP</button>
+      </section>
+    </main>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="leveling.js"></script>
     <script src="code.js"></script>

--- a/style.css
+++ b/style.css
@@ -1,10 +1,34 @@
-html, body, #map {
+html, body {
   height: 100%;
+}
+
+body {
   margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+  position: relative;
 }
 
 #map {
+  height: 100%;
+  width: 100%;
   position: relative;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 #fog {


### PR DESCRIPTION
## Summary
- wrap the Leaflet map in a dedicated container with ARIA labelling and hidden description text for assistive tech
- update page layout styles and add a visually-hidden helper class to accommodate the new structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9a4c70cec8320a45e2529d7688c7f