### PR TITLE
Improve accessibility of fog overlay

### DIFF
--- a/code.js
+++ b/code.js
@@ -7,6 +7,9 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 // Create and append the fog canvas after Leaflet has initialized the map
 const fogCanvas = document.createElement('canvas');
 fogCanvas.id = 'fog';
+fogCanvas.setAttribute('aria-hidden', 'true');
+fogCanvas.setAttribute('role', 'presentation');
+fogCanvas.tabIndex = -1;
 map.getContainer().appendChild(fogCanvas);
 const ctx = fogCanvas.getContext('2d');
 const exploreBtn = document.getElementById('explore');


### PR DESCRIPTION
## Summary
- hide the fog overlay canvas from assistive technology by marking it presentation-only
- ensure the overlay canvas remains non-focusable while continuing to render above the map

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c9cca99b048320be02232d43b23741