### PR TITLE
Improve geolocation status messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     <section id="controls" aria-label="Explorer controls">
       <button id="explore">Start exploring</button>
     </section>
+    <p id="status" class="visually-hidden" role="status" aria-live="polite"></p>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="leveling.js"></script>
     <script src="code.js"></script>


### PR DESCRIPTION
## Summary
- add a screen-reader-only status region to announce geolocation updates
- announce geolocation errors and success states while still logging errors for debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9ccba5a3083208d873f6cf5befe16